### PR TITLE
Meal 관련 ENUM, DTO 등 기본 코드 업로드 및 Spring Cloud 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,17 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://repo.spring.io/milestone' }
+}
+
+ext {
+	set('springCloudVersion', "2025.0.0-RC1")
 }
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.kafka:spring-kafka'
 	compileOnly 'org.projectlombok:lombok'
@@ -41,10 +47,16 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-gson:0.12.5'
 
-//	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
-//	implementation 'org.springframework.cloud:spring-cloud-starter-config'
-//	implementation 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
-//	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	//	implementation 'org.springframework.cloud:spring-cloud-starter-config'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/src/main/java/com/callog/callog_diet/CallogDietApplication.java
+++ b/src/main/java/com/callog/callog_diet/CallogDietApplication.java
@@ -2,7 +2,11 @@ package com.callog.callog_diet;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
+@EnableDiscoveryClient
 @SpringBootApplication
 public class CallogDietApplication {
 

--- a/src/main/java/com/callog/callog_diet/api/open/DietController.java
+++ b/src/main/java/com/callog/callog_diet/api/open/DietController.java
@@ -1,4 +1,0 @@
-package com.callog.callog_diet.api.open;
-
-public class DietController {
-}

--- a/src/main/java/com/callog/callog_diet/api/open/FoodController.java
+++ b/src/main/java/com/callog/callog_diet/api/open/FoodController.java
@@ -6,19 +6,14 @@ import com.callog.callog_diet.service.FoodService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/api/food/v1", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/diet/food", produces = MediaType.APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
 public class FoodController {
 
@@ -33,7 +28,7 @@ public class FoodController {
     }
 
     // 음식 검색
-    @GetMapping(value = "/food")
+    @GetMapping(value = "")
     public ApiResponseDto<List<FoodResponse.FoodListResponse>> food(@RequestParam(required = false) String search) {
         log.info("foodController: /food 호출 {}", search);
         List<FoodResponse.FoodListResponse> foodList = foodService.getFoodList(search);

--- a/src/main/java/com/callog/callog_diet/api/open/MealController.java
+++ b/src/main/java/com/callog/callog_diet/api/open/MealController.java
@@ -1,0 +1,69 @@
+package com.callog.callog_diet.api.open;
+
+import com.callog.callog_diet.domain.MealType;
+import com.callog.callog_diet.domain.dto.meal.MealRequest;
+import com.callog.callog_diet.service.MealService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/diet/meal", produces = MediaType.APPLICATION_JSON_VALUE)
+public class MealController {
+    private final MealService mealService;
+
+    // create: 식단 기록
+    // TODO: 반환값 공통 코드화
+    @PostMapping(value = "")
+    public String createMeal(@RequestBody MealRequest.MealCreateRequest request) {
+
+        return "";
+    }
+
+    // read: 특정 날짜 식단 기록 조회 (아침, 점심, 저녁 한번에)
+    // TODO: 반환값 공통 코드화
+    @GetMapping(value = "")
+    public String readDateMealList(@RequestParam(required = false) @DateTimeFormat(iso=DateTimeFormat.ISO.DATE) LocalDate date) {
+        date = getOrToday(date);
+        // 서비스 호출
+        return "";
+    }
+
+    // read: 특정 날짜 특정 mealType 식단 조회 (음식 수정 화면에서 사용 예정)
+    // TODO: 반환값 공통 코드화
+    @GetMapping(value = "/type")
+    public String readDateMealTypeList(@RequestParam(required = false) @DateTimeFormat(iso=DateTimeFormat.ISO.DATE) LocalDate date,
+                                      @RequestParam MealType mealType) {
+        date = getOrToday(date);
+        // 서비스 호출
+        return "";
+    }
+
+    // update: 식단 기록 수정
+    // TODO: 반환값 공통 코드화
+    @PatchMapping(value = "")
+    public String updateMeal(@RequestBody MealRequest.MealUpdateRequest request) {
+
+        return "";
+    }
+
+    // delete: 식단 기록 삭제
+    // TODO: 반환값 공통 코드화
+    @DeleteMapping(value = "/{mealId}")
+    public String deleteMeal(@PathVariable Long mealId) {
+        return "";
+    }
+
+    // Date Null일 경우, 오늘 날짜 주입
+    private LocalDate getOrToday(LocalDate date) {
+        return (date != null) ? date : LocalDate.now();
+    }
+
+    // read: 식단 기록 전체 조회 (달력, 월단위) (보류)
+}

--- a/src/main/java/com/callog/callog_diet/domain/MealType.java
+++ b/src/main/java/com/callog/callog_diet/domain/MealType.java
@@ -1,0 +1,7 @@
+package com.callog.callog_diet.domain;
+
+public enum MealType {
+    BREAKFAST,
+    LUNCH,
+    DINNER
+}

--- a/src/main/java/com/callog/callog_diet/domain/dto/meal/MealRequest.java
+++ b/src/main/java/com/callog/callog_diet/domain/dto/meal/MealRequest.java
@@ -1,0 +1,39 @@
+package com.callog.callog_diet.domain.dto.meal;
+
+import com.callog.callog_diet.domain.MealType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+public class MealRequest {
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MealCreateRequest {
+        private Long userId;
+        private LocalDate date;
+        private MealType mealType;
+        private Long foodId;
+        private String foodName;
+        private Long amount;
+        // id 자동 생성
+        // amount 기반 carbohydrate, protein, fat, kcal 계산 수행
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MealUpdateRequest {
+        private String id;
+        private Long userId;
+        private Long amount;
+        // id 기반 amount 수정만 지원
+        // amount 기반 carbohydrate, protein, fat, kcal 재계산 수행
+    }
+}

--- a/src/main/java/com/callog/callog_diet/domain/dto/meal/MealResponse.java
+++ b/src/main/java/com/callog/callog_diet/domain/dto/meal/MealResponse.java
@@ -1,0 +1,37 @@
+package com.callog.callog_diet.domain.dto.meal;
+
+import com.callog.callog_diet.domain.MealType;
+import lombok.Builder;
+import lombok.Data;
+
+public class MealResponse {
+
+    @Data
+    @Builder
+    public static class DateMealListResponse {
+        private String id;
+        private MealType mealType;
+        private Long foodId;
+        private String foodName;
+        private Long amount;
+        private double carbohydrate;
+        private double protein;
+        private double fat;
+        private double kcal;
+    }
+
+    @Data
+    @Builder
+    public static class DateMealTypeListResponse {
+        private String id;
+        private Long foodId;
+        private String foodName;
+        private Long amount;
+        private double carbohydrate;
+        private double protein;
+        private double fat;
+        private double kcal;
+    }
+
+
+}

--- a/src/main/java/com/callog/callog_diet/domain/entity/Food.java
+++ b/src/main/java/com/callog/callog_diet/domain/entity/Food.java
@@ -1,4 +1,4 @@
-package com.callog.callog_diet.domain;
+package com.callog.callog_diet.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.Data;
@@ -26,5 +26,4 @@ public class Food {
 
     @Column
     private double kcal;
-
 }

--- a/src/main/java/com/callog/callog_diet/domain/entity/Meal.java
+++ b/src/main/java/com/callog/callog_diet/domain/entity/Meal.java
@@ -1,0 +1,46 @@
+package com.callog.callog_diet.domain.entity;
+
+import com.callog.callog_diet.domain.MealType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Entity
+@Data
+public class Meal {
+    @Id
+    private String id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private MealType mealType;
+
+    @Column(nullable = false)
+    private Long foodId;
+
+    @Column(nullable = false)
+    private String foodName;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column
+    private double carbohydrate;
+
+    @Column
+    private double protein;
+
+    @Column
+    private double fat;
+
+    @Column
+    private double kcal;
+}

--- a/src/main/java/com/callog/callog_diet/domain/repository/FoodRepository.java
+++ b/src/main/java/com/callog/callog_diet/domain/repository/FoodRepository.java
@@ -1,9 +1,7 @@
 package com.callog.callog_diet.domain.repository;
 
-import com.callog.callog_diet.domain.Food;
-
+import com.callog.callog_diet.domain.entity.Food;
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 
 public interface FoodRepository extends JpaRepository<Food, Long> {

--- a/src/main/java/com/callog/callog_diet/domain/repository/MealRepository.java
+++ b/src/main/java/com/callog/callog_diet/domain/repository/MealRepository.java
@@ -1,0 +1,7 @@
+package com.callog.callog_diet.domain.repository;
+
+import com.callog.callog_diet.domain.entity.Meal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MealRepository extends JpaRepository<Meal, Long> {
+}

--- a/src/main/java/com/callog/callog_diet/service/FoodService.java
+++ b/src/main/java/com/callog/callog_diet/service/FoodService.java
@@ -1,6 +1,6 @@
 package com.callog.callog_diet.service;
 
-import com.callog.callog_diet.domain.Food;
+import com.callog.callog_diet.domain.entity.Food;
 import com.callog.callog_diet.domain.dto.food.FoodResponse;
 import com.callog.callog_diet.domain.repository.FoodRepository;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,2 +1,2 @@
 server:
-  port: 8080
+  port: 8082

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 8082
 
 spring:
   datasource:
@@ -17,3 +17,17 @@ spring:
       generate-ddl: true   # 오직 테스트 환경에서만
       show-sql: true
     open-in-view: false
+
+eureka:
+  instance:
+    prefer-ip-address: true
+  #    lease-renewal-interval-in-seconds: 10 # 하트비트 간격(기본 30초)
+  #    lease-expiration-duration-in-seconds: 30 # 만료 시간(기본 90초)
+  client:
+    # export
+    register-with-eureka: true
+    # import
+    fetch-registry: true
+    # 유레카 서버의 위치 주소
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/


### PR DESCRIPTION
- FoodController API prefix 통일 (/diet)
- MealType Enum 생성 (BREAKFAST, LUNCH, DINNER)
- Meal entity, repository 생성
- Meal dto 생성 (MealRequest, MealResponse)
- callog_diet 서비스 eureka 서버에 등록
- 폴더 구조 변경 및 불필요한 파일 삭제