### PR TITLE
feat: 달력에서 식단 조회 기능 구현 및 식단 등록 오류 처리 완료

### DIFF
--- a/src/main/java/com/callog/callog_diet/api/open/MealController.java
+++ b/src/main/java/com/callog/callog_diet/api/open/MealController.java
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 @Slf4j
@@ -34,6 +35,17 @@ public class MealController {
         // TODO: API Gateway 필터로 사용자 정보 받아오기 (일단 하드코딩)
         Long userId = 0L;
         MealResponse.CreateUpdateMealResponse response = mealService.createMeal(userId, request);
+        return ApiResponseDto.createOk(response);
+    }
+
+    // read: 식단 기록 전체 조회 (달력, 월단위)
+    @GetMapping(value="/all")
+    public ApiResponseDto<List<LocalDate>> readMonthMealList(
+            @RequestParam(required = false) YearMonth yearMonth){
+        yearMonth = getOrCurrentMonth(yearMonth);
+        // TODO: API Gateway 필터로 사용자 정보 받아오기 (일단 하드코딩)
+        Long userId = 0L;
+        List<LocalDate> response = mealService.readMonthMealList(userId, yearMonth);
         return ApiResponseDto.createOk(response);
     }
 
@@ -61,7 +73,7 @@ public class MealController {
     }
 
     // update: 식단 기록 수정
-    @PatchMapping(value = "")
+    @PostMapping(value = "/update")
     public ApiResponseDto<MealResponse.CreateUpdateMealResponse> updateMeal(@RequestBody MealRequest.MealUpdateRequest request) {
         // request: {id, userId, amount}
         // TODO: API Gateway 필터로 사용자 정보 받아오기 (일단 하드코딩)
@@ -71,11 +83,11 @@ public class MealController {
     }
 
     // delete: 식단 기록 삭제
-    @DeleteMapping(value = "/{mealId}")
-    public ApiResponseDto<String> deleteMeal(@PathVariable Long mealId) {
+    @PostMapping(value = "/delete")
+    public ApiResponseDto<String> deleteMeal(@RequestBody MealRequest.MealDeleteRequest request) {
         // TODO: API Gateway 필터로 사용자 정보 받아오기 (일단 하드코딩)
         Long userId = 0L;
-        mealService.deleteMeal(userId, mealId);
+        mealService.deleteMeal(userId, request);
         return ApiResponseDto.defaultOk();
     }
 
@@ -84,5 +96,9 @@ public class MealController {
         return (date != null) ? date : LocalDate.now();
     }
 
-    // read: 식단 기록 전체 조회 (달력, 월단위) (보류)
+    private YearMonth getOrCurrentMonth(YearMonth yearMonth) {
+        return (yearMonth != null) ? yearMonth : YearMonth.now();
+    }
+
+
 }

--- a/src/main/java/com/callog/callog_diet/domain/dto/meal/MealRequest.java
+++ b/src/main/java/com/callog/callog_diet/domain/dto/meal/MealRequest.java
@@ -46,4 +46,12 @@ public class MealRequest {
         // id 기반 amount 수정만 지원
         // amount 기반 carbohydrate, protein, fat, kcal 재계산 수행
     }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MealDeleteRequest {
+        private Long mealId;
+    }
 }

--- a/src/main/java/com/callog/callog_diet/domain/repository/MealRepository.java
+++ b/src/main/java/com/callog/callog_diet/domain/repository/MealRepository.java
@@ -6,8 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface MealRepository extends JpaRepository<Meal, Long> {
     List<Meal> findByUserIdAndDate(Long userId, LocalDate date);
     List<Meal> findByUserIdAndDateAndMealType(Long userId, LocalDate date, MealType mealType);
+    List<Meal> findAllByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
+    Optional<Meal> findByUserIdAndDateAndMealTypeAndFoodId(Long userId, LocalDate date, MealType mealType, Long foodId);
 }


### PR DESCRIPTION
- 달력 기준 식단 조회: /diet/meal/all (GET)
- FoodId, UserId, Date, MealType 동일한 레코드 존재할 경우, create가 아닌 update 로직 사용